### PR TITLE
update: implement matrix multiplication

### DIFF
--- a/src/tritonfuzz/generator/builder.py
+++ b/src/tritonfuzz/generator/builder.py
@@ -32,6 +32,8 @@ from tritonfuzz.generator.ops import (
 from tritonfuzz.generator.symbol_table import SymbolTable, TensorVar
 from tritonfuzz.generator.types import (
     CAST_TARGET_DTYPES,
+    BFLOAT16,
+    FLOAT16,
     FLOAT32,
     DType,
     pick_float_dtype,
@@ -39,13 +41,21 @@ from tritonfuzz.generator.types import (
     promote,
 )
 
-# ── Tunables ─────────────────────────────────────────────────────────────────
+# ── Tunables ─────────────────────────────────────────────────────────────
 
 BLOCK_SIZE_CHOICES: list[int] = [64, 128, 256, 512, 1024]
 N_ELEMENTS_CHOICES: list[int] = [512, 1024, 2048, 4096, 8192]
 
 # Accumulation operators used inside generated ``for`` loops.
 _LOOP_ACCUM_OPS: list[str] = ["+", "*", "-"]
+
+# ── Dot (tl.dot) tunables ────────────────────────────────────────────────
+
+_DOT_BLOCK_CHOICES: list[int] = [16, 32, 64]
+_DOT_DIM_CHOICES: list[int] = [64, 128, 256]
+_DOT_K_CHOICES: list[int] = [32, 64, 128]
+_DOT_INPUT_DTYPES: list[DType] = [FLOAT16, BFLOAT16, FLOAT32]
+_DOT_INPUT_WEIGHTS: list[float] = [3.0, 3.0, 1.0]
 
 
 class KernelBuilder:
@@ -78,6 +88,18 @@ class KernelBuilder:
         # ── Atomic store (replaces tl.store epilogue) ────────────────────
         self.use_atomic: bool = False
         self.atomic_op: Optional[AtomicOpTemplate] = None
+
+        # ── Dot product mode (tl.dot, matmul tile) ───────────────────
+        self.use_dot: bool = False
+        self.dot_M: int = 0
+        self.dot_N: int = 0
+        self.dot_K: int = 0
+        self.dot_BLOCK_M: int = 0
+        self.dot_BLOCK_N: int = 0
+        self.dot_BLOCK_K: int = 0
+        self.dot_post_ops: int = 0
+        self.dot_input_dtype: Optional[DType] = None
+        self._dot_acc_name: str = ""
 
         # ── State (accumulated during build) ─────────────────────────────
         self._triton_body: list[str] = []
@@ -148,6 +170,14 @@ class KernelBuilder:
         if self.use_atomic:
             self.atomic_op = pick_atomic_op(rng)
 
+        # Dot product kernel (10 %) — mutually exclusive with atomic
+        self.use_dot = rng.random() > 0.90
+        if self.use_dot:
+            self.use_atomic = False
+            self.atomic_op = None
+            self.insert_loop = False  # K-loop is built into dot template
+            self._plan_dot()
+
         # ── Apply extra_config overrides ─────────────────────────────────
         if "max_body_ops" in self._extra_config:
             self.num_body_ops = min(
@@ -159,11 +189,51 @@ class KernelBuilder:
                 self.num_inputs = cap
                 self.input_dtypes = self.input_dtypes[:cap]
 
+    def _plan_dot(self) -> None:
+        """Configure matrix dimensions and block sizes for a dot kernel."""
+        rng = self.rng
+
+        # Block sizes (must be >= 16 for tensor cores)
+        self.dot_BLOCK_M = rng.choice(_DOT_BLOCK_CHOICES)
+        self.dot_BLOCK_N = rng.choice(_DOT_BLOCK_CHOICES)
+        self.dot_BLOCK_K = rng.choice(_DOT_BLOCK_CHOICES)
+
+        # Matrix dimensions (must be multiples of block sizes)
+        m_choices = [d for d in _DOT_DIM_CHOICES if d >= self.dot_BLOCK_M]
+        n_choices = [d for d in _DOT_DIM_CHOICES if d >= self.dot_BLOCK_N]
+        k_choices = [d for d in _DOT_K_CHOICES if d >= self.dot_BLOCK_K]
+
+        self.dot_M = rng.choice(m_choices) if m_choices else self.dot_BLOCK_M
+        self.dot_N = rng.choice(n_choices) if n_choices else self.dot_BLOCK_N
+        self.dot_K = rng.choice(k_choices) if k_choices else self.dot_BLOCK_K
+
+        # Ensure exact divisibility
+        self.dot_M = (self.dot_M // self.dot_BLOCK_M) * self.dot_BLOCK_M
+        self.dot_N = (self.dot_N // self.dot_BLOCK_N) * self.dot_BLOCK_N
+        self.dot_K = (self.dot_K // self.dot_BLOCK_K) * self.dot_BLOCK_K
+
+        # Input dtype for both matrices (tl.dot requires matching types)
+        self.dot_input_dtype = rng.choices(
+            _DOT_INPUT_DTYPES, weights=_DOT_INPUT_WEIGHTS, k=1,
+        )[0]
+
+        # Number of element-wise post-ops on the dot result
+        self.dot_post_ops = rng.randint(0, 3)
+
+        # Override general planning for dot mode
+        self.num_inputs = 2
+        self.input_dtypes = [self.dot_input_dtype, self.dot_input_dtype]
+        self.num_body_ops = self.dot_post_ops
+        self.use_mask = False  # dimensions are aligned, no masking needed
+        self.n_elements = self.dot_M * self.dot_N  # total output elements
+
     # ================================================================== #
     #  Phase 2 – Emit loads (§4.2.1)                                       #
     # ================================================================== #
 
     def _emit_loads(self) -> None:
+        if self.use_dot:
+            return  # Dot loads are part of the K-loop in assembly
         for i in range(self.num_inputs):
             var_name = self.symtab.fresh_name("v")  # v_0, v_1, …
             dt = self.input_dtypes[i]
@@ -189,6 +259,10 @@ class KernelBuilder:
     # ================================================================== #
 
     def _emit_body(self) -> None:
+        if self.use_dot:
+            self._emit_dot_body()
+            return
+
         ops_emitted = 0
         loop_inserted = False
 
@@ -206,6 +280,18 @@ class KernelBuilder:
 
             self._emit_one_op()
             ops_emitted += 1
+
+    def _emit_dot_body(self) -> None:
+        """Register the dot accumulator and emit optional post-ops."""
+        acc_name = self.symtab.fresh_name("v")
+        dot_shape = ("BLOCK_M", "BLOCK_N")
+        self.symtab.add(TensorVar(acc_name, FLOAT32, is_block=True, shape=dot_shape))
+        self._dot_acc_name = acc_name
+        self._ops_used.append("dot")
+
+        # Emit optional element-wise post-ops on the accumulator
+        for _ in range(self.dot_post_ops):
+            self._emit_one_op()
 
     # ── Single-op dispatcher ─────────────────────────────────────────────
 
@@ -255,7 +341,7 @@ class KernelBuilder:
         self._triton_body.append(f"{indent}{out_name} = {op.triton_fmt.format(inp.name)}")
         self._torch_body.append(f"{indent}{out_name} = {op.torch_fmt.format(inp.name)}")
 
-        self.symtab.add(TensorVar(out_name, inp.dtype, is_block=True))
+        self.symtab.add(TensorVar(out_name, inp.dtype, is_block=True, shape=inp.shape))
         self._ops_used.append(op.name)
 
     # ── Binary op emission ───────────────────────────────────────────────
@@ -275,7 +361,7 @@ class KernelBuilder:
         )
 
         out_dt = promote(a.dtype, b.dtype) if op.output_dtype_rule == "promote" else a.dtype
-        self.symtab.add(TensorVar(out_name, out_dt, is_block=True))
+        self.symtab.add(TensorVar(out_name, out_dt, is_block=True, shape=a.shape))
         self._ops_used.append(op.name)
 
     # ── ``tl.where`` emission (§4.2.2 Logic) ────────────────────────────
@@ -306,7 +392,7 @@ class KernelBuilder:
         )
 
         out_dt = promote(true_var.dtype, false_var.dtype)
-        self.symtab.add(TensorVar(out_name, out_dt, is_block=True))
+        self.symtab.add(TensorVar(out_name, out_dt, is_block=True, shape=true_var.shape))
         self._ops_used.append("where")
 
     # ── Explicit type-cast emission (§4.2.3) ─────────────────────────────
@@ -332,7 +418,7 @@ class KernelBuilder:
         self._triton_body.append(f"{indent}{out_name} = {src.name}.to({target_dtype.triton})")
         self._torch_body.append(f"{indent}{out_name} = {src.name}.to({target_dtype.torch})")
 
-        self.symtab.add(TensorVar(out_name, target_dtype, is_block=True))
+        self.symtab.add(TensorVar(out_name, target_dtype, is_block=True, shape=src.shape))
         self._ops_used.append(f"cast_to_{target_dtype.short}")
 
     # ── For-loop emission (§4.3 Control Flow) ────────────────────────────
@@ -376,7 +462,7 @@ class KernelBuilder:
         )
 
         out_dt = promote(src.dtype, operand.dtype)
-        self.symtab.add(TensorVar(acc_name, out_dt, is_block=True))
+        self.symtab.add(TensorVar(acc_name, out_dt, is_block=True, shape=src.shape))
         self._ops_used.append(f"loop_{accum_op}")
 
     # ================================================================== #
@@ -391,6 +477,9 @@ class KernelBuilder:
     # ================================================================== #
 
     def _assemble_triton_source(self) -> str:
+        if self.use_dot:
+            return self._assemble_dot_triton_source()
+
         seed = self.seed
         ptr_args = ", ".join(f"in_ptr{i}" for i in range(self.num_inputs))
         out_var = self._output_var.name if self._output_var else "v_0"
@@ -431,7 +520,56 @@ class KernelBuilder:
 
         return "\n".join(lines) + "\n"
 
+    def _assemble_dot_triton_source(self) -> str:
+        """Assemble a matmul-tile kernel using ``tl.dot``."""
+        seed = self.seed
+        acc = self._dot_acc_name
+        out_var = self._output_var.name if self._output_var else acc
+
+        lines: list[str] = [
+            "import triton",
+            "import triton.language as tl",
+            "",
+            "",
+            "@triton.jit",
+            f"def triton_kernel_seed_{seed}(",
+            "    a_ptr, b_ptr, out_ptr,",
+            "    M, N, K,",
+            "    stride_am, stride_ak,",
+            "    stride_bk, stride_bn,",
+            "    stride_cm, stride_cn,",
+            "    BLOCK_M: tl.constexpr,",
+            "    BLOCK_N: tl.constexpr,",
+            "    BLOCK_K: tl.constexpr,",
+            "):",
+            "    pid_m = tl.program_id(0)",
+            "    pid_n = tl.program_id(1)",
+            "    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)",
+            "    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)",
+            f"    {acc} = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)",
+            "    for k_start in range(0, K, BLOCK_K):",
+            "        offs_k = k_start + tl.arange(0, BLOCK_K)",
+            "        a = tl.load(a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)",
+            "        b = tl.load(b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)",
+            f"        {acc} += tl.dot(a, b)",
+        ]
+
+        # Post-ops from body
+        for line in self._triton_body:
+            lines.append(f"    {line}")
+
+        # Store
+        lines.extend([
+            "    c_ptrs = out_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn",
+            f"    tl.store(c_ptrs, {out_var})",
+        ])
+
+        return "\n".join(lines) + "\n"
+
     def _assemble_torch_ref_source(self) -> str:
+        if self.use_dot:
+            return self._assemble_dot_torch_ref_source()
+
         seed = self.seed
         input_args = ", ".join(f"x{i}" for i in range(self.num_inputs))
         out_var = self._output_var.name if self._output_var else "v_0"
@@ -450,13 +588,34 @@ class KernelBuilder:
 
         return "\n".join(lines) + "\n"
 
+    def _assemble_dot_torch_ref_source(self) -> str:
+        """Assemble the PyTorch reference for a dot kernel."""
+        seed = self.seed
+        acc = self._dot_acc_name
+        out_var = self._output_var.name if self._output_var else acc
+
+        lines: list[str] = [
+            "import torch",
+            "",
+            "",
+            f"def torch_ref_seed_{seed}(a, b):",
+            f"    {acc} = torch.matmul(a.float(), b.float())",
+        ]
+
+        for line in self._torch_body:
+            lines.append(f"    {line}")
+
+        lines.append(f"    return {out_var}")
+
+        return "\n".join(lines) + "\n"
+
     # ================================================================== #
     #  Metadata                                                            #
     # ================================================================== #
 
     def _build_metadata(self) -> dict:
         meta = {
-            "generator_version": "0.2.0",
+            "generator_version": "0.3.0",
             "seed": self.seed,
             "num_inputs": self.num_inputs,
             "input_dtypes": [d.torch for d in self.input_dtypes],
@@ -475,10 +634,24 @@ class KernelBuilder:
             "loop_trip_count": self.loop_trip_count,
             "mix_dtypes": self.mix_dtypes,
             "has_atomics": self.use_atomic,
+            "use_dot": self.use_dot,
         }
         if self.use_atomic and self.atomic_op is not None:
             meta["atomic_op"] = self.atomic_op.name
             meta["output_init"] = self.atomic_op.output_init
             self._ops_used.append(self.atomic_op.name)
             meta["ops_used"] = list(self._ops_used)
+        if self.use_dot:
+            meta["dot_M"] = self.dot_M
+            meta["dot_N"] = self.dot_N
+            meta["dot_K"] = self.dot_K
+            meta["dot_BLOCK_M"] = self.dot_BLOCK_M
+            meta["dot_BLOCK_N"] = self.dot_BLOCK_N
+            meta["dot_BLOCK_K"] = self.dot_BLOCK_K
+            meta["input_shapes"] = [
+                [self.dot_M, self.dot_K],
+                [self.dot_K, self.dot_N],
+            ]
+            meta["output_shape"] = [self.dot_M, self.dot_N]
+            meta["output_dtype"] = "torch.float32"  # dot accumulator is always fp32
         return meta

--- a/src/tritonfuzz/generator/ops.py
+++ b/src/tritonfuzz/generator/ops.py
@@ -37,10 +37,10 @@ class OpCategory(str, Enum):
     LOGIC              = "logic"
     TYPE_CAST          = "type_cast"
     ATOMIC             = "atomic"
+    DOT                = "dot"
 
     # Future stubs
     REDUCTION    = "reduction"
-    DOT          = "dot"
     POINTER_MATH = "pointer_math"
 
 

--- a/src/tritonfuzz/generator/symbol_table.py
+++ b/src/tritonfuzz/generator/symbol_table.py
@@ -22,6 +22,7 @@ class TensorVar:
     name: str
     dtype: DType
     is_block: bool = True  # True → BLOCK_SIZE-shaped; False → scalar
+    shape: tuple[str, ...] = ()  # e.g. ("BLOCK_SIZE",) for 1D, ("BLOCK_M","BLOCK_N") for 2D; () = default 1D
 
 
 class SymbolTable:
@@ -68,11 +69,14 @@ class SymbolTable:
         *,
         is_block: bool = True,
         require_float: bool = False,
+        shape: Optional[tuple[str, ...]] = None,
     ) -> Optional[TensorVar]:
         """Pick a random variable matching the filters, or ``None``."""
         candidates = [v for v in self.all_vars() if v.is_block == is_block]
         if require_float:
             candidates = [v for v in candidates if v.dtype.is_float]
+        if shape is not None:
+            candidates = [v for v in candidates if v.shape == shape]
         return rng.choice(candidates) if candidates else None
 
     def pick_two(
@@ -81,16 +85,19 @@ class SymbolTable:
         *,
         is_block: bool = True,
         prefer_same_dtype: bool = False,
+        shape: Optional[tuple[str, ...]] = None,
     ) -> tuple[Optional[TensorVar], Optional[TensorVar]]:
         """Pick two (possibly identical) variables for binary ops."""
-        a = self.pick_random(rng, is_block=is_block)
+        a = self.pick_random(rng, is_block=is_block, shape=shape)
         if a is None:
             return None, None
         if prefer_same_dtype:
             same = [v for v in self.all_vars() if v.is_block == is_block and v.dtype == a.dtype]
-            b = rng.choice(same) if same else self.pick_random(rng, is_block=is_block)
+            if shape is not None:
+                same = [v for v in same if v.shape == shape]
+            b = rng.choice(same) if same else self.pick_random(rng, is_block=is_block, shape=shape)
         else:
-            b = self.pick_random(rng, is_block=is_block)
+            b = self.pick_random(rng, is_block=is_block, shape=shape)
         return a, b
 
     def last_var(self) -> Optional[TensorVar]:

--- a/src/tritonfuzz/reducer.py
+++ b/src/tritonfuzz/reducer.py
@@ -791,6 +791,12 @@ class Reducer:
         The script embeds both the Triton kernel and the PyTorch reference,
         allocates inputs according to metadata, and runs the comparison.
         """
+        # Dot kernels have a completely different launch pattern
+        if metadata.get("use_dot"):
+            return Reducer._build_dot_repro_script(
+                seed, triton_src, torch_src, metadata, compile_options,
+            )
+
         bs = metadata.get("block_size", 256)
         ne = metadata.get("n_elements", 1024)
         n_in = metadata.get("num_inputs", 1)
@@ -884,6 +890,80 @@ class Reducer:
             ' {diff.max().item():.6e}")\n',
             '        print(f"  golden[:8]: {golden[:8]}")\n',
             '        print(f"  triton[:8]: {out[:8]}")\n',
+            "\n\n",
+            'if __name__ == "__main__":\n',
+            "    main()\n",
+        ]
+        return "".join(parts)
+
+    @staticmethod
+    def _build_dot_repro_script(
+        seed: int,
+        triton_src: str,
+        torch_src: str,
+        metadata: dict,
+        compile_options: dict,
+    ) -> str:
+        """Generate a standalone reproducer for a dot-product kernel."""
+        kfn = metadata.get("kernel_fn_name", f"triton_kernel_seed_{seed}")
+        rfn = metadata.get("ref_fn_name", f"torch_ref_seed_{seed}")
+        M = metadata.get("dot_M", 128)
+        N = metadata.get("dot_N", 128)
+        K = metadata.get("dot_K", 64)
+        BM = metadata.get("dot_BLOCK_M", 32)
+        BN = metadata.get("dot_BLOCK_N", 32)
+        BK = metadata.get("dot_BLOCK_K", 32)
+        dt = metadata.get("input_dtypes", ["torch.float32"])[0]
+
+        parts: list[str] = [
+            "#!/usr/bin/env python3\n",
+            f'"""Minimal reproducer for TritonFuzz seed {seed} (dot kernel).\n',
+            "\n",
+            "To capture full IR dumps, run with:\n",
+            "  MLIR_ENABLE_DUMP=1 TRITON_ALWAYS_COMPILE=1 \\\n",
+            "  LLVM_IR_ENABLE_DUMP=1 \\\n",
+            "  NVPTX_ENABLE_DUMP=1 python reproduce.py\n",
+            '"""\n',
+            "import torch\n",
+            "\n",
+            "# ── Triton kernel "
+            "────────────────────────────────────────────────\n",
+            triton_src,
+            "\n",
+            "# ── PyTorch reference "
+            "────────────────────────────────────────────\n",
+            torch_src,
+            "\n\n",
+            "def main():\n",
+            f"    M, N, K = {M}, {N}, {K}\n",
+            f"    BLOCK_M, BLOCK_N, BLOCK_K = {BM}, {BN}, {BK}\n",
+            f'    a = torch.randn(M, K, device="cuda", dtype={dt})\n',
+            f'    b = torch.randn(K, N, device="cuda", dtype={dt})\n',
+            f'    out = torch.empty(M, N, device="cuda", dtype=torch.float32)\n',
+            "\n",
+            "    # Golden output\n",
+            f"    golden = {rfn}(a, b)\n",
+            "\n",
+            "    # Triton output\n",
+            "    grid = (M // BLOCK_M, N // BLOCK_N)\n",
+            f"    {kfn}[grid](\n",
+            "        a, b, out,\n",
+            "        M, N, K,\n",
+            "        a.stride(0), a.stride(1),\n",
+            "        b.stride(0), b.stride(1),\n",
+            "        out.stride(0), out.stride(1),\n",
+            "        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,\n",
+            "    )\n",
+            "\n",
+            "    # Compare\n",
+            "    if torch.allclose(golden.float(), out.float(), atol=1e-2, rtol=1e-2, equal_nan=True):\n",
+            '        print("PASS")\n',
+            "    else:\n",
+            "        diff = (golden.float() - out.float()).abs()\n",
+            '        print(f"FAIL — max_abs_diff:'
+            ' {diff.max().item():.6e}")\n',
+            '        print(f"  golden[:4,:4]: {golden[:4,:4]}")\n',
+            '        print(f"  triton[:4,:4]: {out[:4,:4]}")\n',
             "\n\n",
             'if __name__ == "__main__":\n',
             "    main()\n",

--- a/src/tritonfuzz/runtime.py
+++ b/src/tritonfuzz/runtime.py
@@ -142,6 +142,9 @@ class Runtime:
         produced by the Generator.
         """
         meta = kernel.metadata
+        if meta.get("use_dot"):
+            return self._allocate_dot_inputs(kernel)
+
         n_elements = meta.get("n_elements", 1024)
         num_inputs = meta.get("num_inputs", 1)
         dtype_strs: list[str] = meta.get("input_dtypes", ["torch.float32"] * num_inputs)
@@ -163,6 +166,19 @@ class Runtime:
             tensors.append(t)
 
         return tensors
+
+    def _allocate_dot_inputs(self, kernel: GeneratedKernel) -> list[torch.Tensor]:
+        """Allocate 2D matrix inputs for a dot-product kernel."""
+        meta = kernel.metadata
+        M = meta["dot_M"]
+        N = meta["dot_N"]
+        K = meta["dot_K"]
+        dt_str = meta["input_dtypes"][0]
+        dt = _TORCH_DTYPE_MAP.get(dt_str, torch.float32)
+
+        A = torch.randn(M, K, device=self._device, dtype=dt)
+        B = torch.randn(K, N, device=self._device, dtype=dt)
+        return [A, B]
 
     def _run_torch_ref(
         self,
@@ -192,12 +208,11 @@ class Runtime:
         compiled: CompilationResult,
         inputs: list[torch.Tensor],
     ) -> torch.Tensor:
-        """Launch the compiled Triton kernel and return its output.
-
-        Dynamically imports and calls the ``@triton.jit`` kernel using the
-        standard Triton grid-launch syntax.
-        """
+        """Launch the compiled Triton kernel and return its output."""
         meta = kernel.metadata
+        if meta.get("use_dot"):
+            return self._run_dot_triton_kernel(kernel, compiled, inputs)
+
         n_elements = meta.get("n_elements", 1024)
         block_size = meta.get("block_size", 256)
         output_dtype_str = meta.get("output_dtype", "torch.float32")
@@ -230,6 +245,41 @@ class Runtime:
 
         grid = ((n_elements + block_size - 1) // block_size,)
         jit_fn[grid](*inputs, out, n_elements, BLOCK_SIZE=block_size)
+
+        return out
+
+    def _run_dot_triton_kernel(
+        self,
+        kernel: GeneratedKernel,
+        compiled: CompilationResult,
+        inputs: list[torch.Tensor],
+    ) -> torch.Tensor:
+        """Launch a dot-product kernel with 2D grid and stride args."""
+        meta = kernel.metadata
+        M = meta["dot_M"]
+        N = meta["dot_N"]
+        K = meta["dot_K"]
+        BLOCK_M = meta["dot_BLOCK_M"]
+        BLOCK_N = meta["dot_BLOCK_N"]
+        BLOCK_K = meta["dot_BLOCK_K"]
+
+        output_dtype_str = meta.get("output_dtype", "torch.float32")
+        output_dtype = _TORCH_DTYPE_MAP.get(output_dtype_str, torch.float32)
+
+        A, B = inputs[0], inputs[1]
+        out = torch.empty(M, N, device=self._device, dtype=output_dtype)
+
+        jit_fn = self._load_jit_fn_from_source(kernel)
+
+        grid = (M // BLOCK_M, N // BLOCK_N)
+        jit_fn[grid](
+            A, B, out,
+            M, N, K,
+            A.stride(0), A.stride(1),
+            B.stride(0), B.stride(1),
+            out.stride(0), out.stride(1),
+            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
+        )
 
         return out
 


### PR DESCRIPTION
Implement Matrix Multiplication (tl.dot)
Matrix multiplication is the primary use case for Triton, making this a high-priority feature. The Oracle's dynamic tolerance system is actually already pre-configured to expect it: it has a specific tolerance multiplier built-in for dot operations ("dot": 3.0).

Where to start: Define tl.dot in src/tritonfuzz/generator/ops.py.
- Modify KernelBuilder in src/tritonfuzz/generator/builder.py to support 2D block shapes. Currently, variables are tracked as either is_block or scalar. You will need to upgrade TensorVar to track specific shape dimensions (e.g., M x K and K x N) so the builder can validly chain dot products.