### PR TITLE
update: implement reductions

### DIFF
--- a/src/tritonfuzz/generator/builder.py
+++ b/src/tritonfuzz/generator/builder.py
@@ -28,6 +28,7 @@ from tritonfuzz.generator.ops import (
     pick_atomic_op,
     pick_category,
     pick_op_from_category,
+    pick_reduction_op,
 )
 from tritonfuzz.generator.symbol_table import SymbolTable, TensorVar
 from tritonfuzz.generator.types import (
@@ -303,6 +304,10 @@ class KernelBuilder:
             self._emit_cast(indent)
             return
 
+        if category == OpCategory.REDUCTION:
+            self._emit_reduction(indent)
+            return
+
         # For the LOGIC category, half the time emit ``where`` instead of
         # min/max so that we exercise predicate-based branching (§4.3).
         if category == OpCategory.LOGIC and rng.random() > 0.5:
@@ -420,6 +425,61 @@ class KernelBuilder:
 
         self.symtab.add(TensorVar(out_name, target_dtype, is_block=True, shape=src.shape))
         self._ops_used.append(f"cast_to_{target_dtype.short}")
+
+    # ── Reduction emission (tl.sum / tl.max / tl.min) ───────────────────
+
+    def _emit_reduction(self, indent: str = "") -> None:
+        """Emit a reduction followed by a broadcast-back binary op.
+
+        Pattern::
+
+            v_N_red = tl.sum(v_M, axis=0)      # scalar
+            v_N     = v_K + v_N_red             # broadcast back to block
+
+        This exercises the Triton compiler's reduction lowering while
+        keeping the final registered variable block-shaped so that
+        subsequent ops and the store epilogue work unchanged.
+
+        Only operates on 1D block variables (``shape == ()``).  In dot
+        mode all variables are 2D, so this gracefully becomes a no-op.
+        """
+        rng = self.rng
+
+        # Pick a 1D block variable to reduce
+        inp = self.symtab.pick_random(rng, is_block=True, require_float=True, shape=())
+        if inp is None:
+            inp = self.symtab.pick_random(rng, is_block=True, shape=())
+        if inp is None:
+            return  # no 1D blocks available (e.g. dot mode)
+
+        red_op = pick_reduction_op(rng)
+
+        # Emit the reduction → scalar
+        scalar_name = self.symtab.fresh_name("r")
+        self._triton_body.append(
+            f"{indent}{scalar_name} = {red_op.triton_fmt.format(inp.name)}"
+        )
+        self._torch_body.append(
+            f"{indent}{scalar_name} = {red_op.torch_fmt.format(inp.name)}"
+        )
+
+        # Broadcast back: combine scalar with a block variable
+        block_var = self.symtab.pick_random(rng, is_block=True, shape=())
+        if block_var is None:
+            return
+
+        out_name = self.symtab.fresh_name("v")
+        accum_op = rng.choice(["+", "*"])
+        self._triton_body.append(
+            f"{indent}{out_name} = {block_var.name} {accum_op} {scalar_name}"
+        )
+        self._torch_body.append(
+            f"{indent}{out_name} = {block_var.name} {accum_op} {scalar_name}"
+        )
+
+        out_dt = promote(block_var.dtype, inp.dtype)
+        self.symtab.add(TensorVar(out_name, out_dt, is_block=True, shape=block_var.shape))
+        self._ops_used.append(red_op.name)
 
     # ── For-loop emission (§4.3 Control Flow) ────────────────────────────
 
@@ -615,7 +675,7 @@ class KernelBuilder:
 
     def _build_metadata(self) -> dict:
         meta = {
-            "generator_version": "0.3.0",
+            "generator_version": "0.4.0",
             "seed": self.seed,
             "num_inputs": self.num_inputs,
             "input_dtypes": [d.torch for d in self.input_dtypes],

--- a/src/tritonfuzz/generator/ops.py
+++ b/src/tritonfuzz/generator/ops.py
@@ -39,8 +39,9 @@ class OpCategory(str, Enum):
     ATOMIC             = "atomic"
     DOT                = "dot"
 
-    # Future stubs
     REDUCTION    = "reduction"
+
+    # Future stubs
     POINTER_MATH = "pointer_math"
 
 
@@ -141,6 +142,38 @@ def pick_atomic_op(rng: random.Random) -> AtomicOpTemplate:
     weights = [op.weight for op in ATOMIC_OPS]
     return rng.choices(ATOMIC_OPS, weights=weights, k=1)[0]
 
+
+# ── Reduction operations (tl.sum, tl.max, tl.min) ───────────────────────────
+
+
+@dataclass(frozen=True)
+class ReductionOpTemplate:
+    """Describes a reduction operation that collapses a block to a scalar.
+
+    The builder emits the reduction then immediately combines the scalar
+    result with a block-shaped variable (broadcasting), so the final
+    registered variable remains block-shaped and can be stored normally.
+    """
+
+    name: str
+    triton_fmt: str   # e.g. "tl.sum({0}, axis=0)"
+    torch_fmt: str    # e.g. "torch.sum({0})"
+    weight: float = 1.0
+    requires_float: bool = False
+
+
+REDUCTION_OPS: list[ReductionOpTemplate] = [
+    ReductionOpTemplate("reduce_sum", "tl.sum({0}, axis=0)",  "torch.sum({0})",  3.0, False),
+    ReductionOpTemplate("reduce_max", "tl.max({0}, axis=0)",  "torch.max({0})",  2.0, False),
+    ReductionOpTemplate("reduce_min", "tl.min({0}, axis=0)",  "torch.min({0})",  2.0, False),
+]
+
+
+def pick_reduction_op(rng: random.Random) -> ReductionOpTemplate:
+    """Weighted random selection of a reduction operation."""
+    weights = [op.weight for op in REDUCTION_OPS]
+    return rng.choices(REDUCTION_OPS, weights=weights, k=1)[0]
+
 # ── Convenience aggregates ───────────────────────────────────────────────────
 
 ALL_TEMPLATE_OPS: list[OpTemplate] = UNARY_OPS + BINARY_OPS + LOGIC_BINARY_OPS
@@ -152,6 +185,7 @@ CATEGORY_WEIGHTS: dict[OpCategory, float] = {
     OpCategory.ELEMENTWISE_BINARY: 4.0,
     OpCategory.LOGIC:              2.0,
     OpCategory.TYPE_CAST:          1.5,
+    OpCategory.REDUCTION:          1.5,
 }
 
 # ── Comparison primitives for ``tl.where`` condition expressions ─────────────

--- a/src/tritonfuzz/oracle.py
+++ b/src/tritonfuzz/oracle.py
@@ -117,6 +117,9 @@ _OP_TOLERANCE_MULTIPLIERS: dict[str, float] = {
     "sqrt": 1.5,
     "div":  1.5,
     "dot":  3.0,
+    "reduce_sum": 2.0,
+    "reduce_max": 1.5,
+    "reduce_min": 1.5,
 }
 
 # Output dtype → base tolerance override.


### PR DESCRIPTION
Reductions are another "Future stub" that fundamentally change tensor shapes.

Where to start: Add reduction templates to ops.py.

- Update SymbolTable and TensorVar in src/tritonfuzz/generator/symbol_table.py to track the dimensional changes when a block is reduced along an axis.

- Update builder.py to correctly emit the PyTorch equivalent (e.g., torch.sum(..., dim=...)) to ensure the golden reference matches the Triton output.