### PR TITLE
update(ControlFlow): Add mandatory cast

### DIFF
--- a/src/tritonfuzz/generator/builder.py
+++ b/src/tritonfuzz/generator/builder.py
@@ -1593,19 +1593,20 @@ class KernelBuilder:
             false_dtype = fb.dtype if fb else FLOAT32
             false_shape = fb.shape if fb else ()
 
-        # ── Reconcile dtypes: insert casts so both branches produce
-        #    the same type for the SSA phi-node ────────────────────────
+        # ── Reconcile dtypes: always cast in both branches so the
+        #    SSA phi-node has a consistent type.  Unconditional casts
+        #    are needed because Triton's type inference may promote
+        #    intermediates (e.g. tl.sum(bf16)->fp32) in ways that our
+        #    dtype model does not track. ───────────────────────────────
         out_dt = promote(true_dtype, false_dtype)
 
-        if true_dtype != out_dt:
-            # Insert cast at the end of the true branch (before the else)
-            self._triton_body.insert(true_cast_idx, f"{inner}{_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.insert(true_cast_idx_torch, f"{inner}{_cast_line(out_name, out_dt, framework='torch')}")
+        # Cast at the end of the true branch (before the else)
+        self._triton_body.insert(true_cast_idx, f"{inner}{_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.insert(true_cast_idx_torch, f"{inner}{_cast_line(out_name, out_dt, framework='torch')}")
 
-        if false_dtype != out_dt:
-            # Append cast at the end of the false branch
-            self._triton_body.append(f"{inner}{_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.append(f"{inner}{_cast_line(out_name, out_dt, framework='torch')}")
+        # Cast at the end of the false branch
+        self._triton_body.append(f"{inner}{_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.append(f"{inner}{_cast_line(out_name, out_dt, framework='torch')}")
 
         # ── Restore and register unified output ──────────────────────
         self.symtab.restore(snap)
@@ -1807,22 +1808,23 @@ class KernelBuilder:
         # ── Reconcile dtypes across all three paths ──────────────────
         out_dt = promote(promote(inner_true_dtype, inner_false_dtype), outer_false_dtype)
 
-        # Insert casts in reverse index order so earlier inserts don't
-        # shift later indices.
-        if outer_false_dtype != out_dt:
-            self._triton_body.append(f"    {_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.append(f"    {_cast_line(out_name, out_dt, framework='torch')}")
+        # Always insert casts in all branches to ensure the SSA
+        # phi-node has a consistent type, even when our dtype model
+        # agrees (Triton's inference may differ due to implicit
+        # promotions like tl.sum(bf16)->fp32).
+        # Insert in reverse index order so earlier inserts don't shift
+        # later indices.
+        self._triton_body.append(f"    {_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.append(f"    {_cast_line(out_name, out_dt, framework='torch')}")
 
-        if inner_false_dtype != out_dt:
-            self._triton_body.insert(inner_false_cast_idx, f"        {_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.insert(inner_false_cast_idx_torch, f"        {_cast_line(out_name, out_dt, framework='torch')}")
-            # Shift inner_true index since we inserted above it
-            inner_true_cast_idx += 1
-            inner_true_cast_idx_torch += 1
+        self._triton_body.insert(inner_false_cast_idx, f"        {_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.insert(inner_false_cast_idx_torch, f"        {_cast_line(out_name, out_dt, framework='torch')}")
+        # Shift inner_true index since we inserted above it
+        inner_true_cast_idx += 1
+        inner_true_cast_idx_torch += 1
 
-        if inner_true_dtype != out_dt:
-            self._triton_body.insert(inner_true_cast_idx, f"        {_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.insert(inner_true_cast_idx_torch, f"        {_cast_line(out_name, out_dt, framework='torch')}")
+        self._triton_body.insert(inner_true_cast_idx, f"        {_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.insert(inner_true_cast_idx_torch, f"        {_cast_line(out_name, out_dt, framework='torch')}")
 
         # ── Register unified output ──────────────────────────────────
         self.symtab.restore(snap)
@@ -2043,13 +2045,13 @@ class KernelBuilder:
         # ── Reconcile dtypes between if and else branches ────────────
         out_dt = promote(true_dtype, false_dtype)
 
-        if true_dtype != out_dt:
-            self._triton_body.insert(true_cast_idx, f"    {_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.insert(true_cast_idx_torch, f"    {_cast_line(out_name, out_dt, framework='torch')}")
+        # Always cast in both branches to guarantee the SSA phi-node
+        # has a consistent type.
+        self._triton_body.insert(true_cast_idx, f"    {_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.insert(true_cast_idx_torch, f"    {_cast_line(out_name, out_dt, framework='torch')}")
 
-        if false_dtype != out_dt:
-            self._triton_body.append(f"    {_cast_line(out_name, out_dt, framework='triton')}")
-            self._torch_body.append(f"    {_cast_line(out_name, out_dt, framework='torch')}")
+        self._triton_body.append(f"    {_cast_line(out_name, out_dt, framework='triton')}")
+        self._torch_body.append(f"    {_cast_line(out_name, out_dt, framework='torch')}")
 
         # ── Register unified output ──────────────────────────────────
         self.symtab.restore(snap)

--- a/src/tritonfuzz/generator/types.py
+++ b/src/tritonfuzz/generator/types.py
@@ -79,14 +79,25 @@ def pick_float_dtype(rng: random.Random) -> DType:
 
 
 def promote(a: DType, b: DType) -> DType:
-    """Return the 'wider' type, following Triton / PyTorch implicit rules.
+    """Return the 'wider' type, following Triton's implicit promotion rules.
 
-    * Float always wins over int.
-    * Among same kind, larger ``bits`` wins.
+    When mixing float and int, Triton first converts the integer to
+    a standard float of at least the same bit-width (e.g. int32→float32),
+    then picks the wider float.  This means ``promote(bf16, int32)``
+    returns **float32**, not bf16.
+
+    Among same kind, larger ``bits`` wins.
     """
-    if a.is_float and not b.is_float:
-        return a
-    if b.is_float and not a.is_float:
-        return b
-    # Same kind → wider bits wins
-    return a if a.bits >= b.bits else b
+    if a.is_float and b.is_float:
+        return a if a.bits >= b.bits else b
+    if a.is_int and b.is_int:
+        return a if a.bits >= b.bits else b
+
+    # Mixed float/int: convert the int to its natural float width,
+    # then promote between the two floats.
+    if a.is_float and b.is_int:
+        int_as_float_bits = max(b.bits, 32)  # int32→fp32, int64→fp64
+        return a if a.bits >= int_as_float_bits else FLOAT32 if int_as_float_bits == 32 else FLOAT64
+    # b.is_float and a.is_int
+    int_as_float_bits = max(a.bits, 32)
+    return b if b.bits >= int_as_float_bits else FLOAT32 if int_as_float_bits == 32 else FLOAT64


### PR DESCRIPTION
See https://github.com/JueonPark/TritonFuzz/pull/18 for previous patch

All **control-flow type unification** errors are now eliminated:

| Category | Before | After | Change |
|----------|--------|-------|--------|
| **if/else branch type mismatch** | 6 | **0** | Fixed |
| **Loop-carried variable type mismatch** | 6 | **0** | Fixed |
| **Total CompileErr** | 65 | **56** | -9 |
| **Pass** | 35 | **43** | +8 |

The fixes span three files:

1. **symbol_table.py** — `restore()` no longer resets the name counter, so if/else branches generate distinct variable names and avoid spurious SSA phi-node type conflicts.

2. **types.py** — `promote()` now correctly handles mixed float/int promotion: int32 is first converted to float32 (matching Triton's behavior), then the wider float wins. This means `promote(bf16, int32) = fp32` instead of the incorrect `bf16`.

3. **builder.py** — Four changes:
   - `_emit_loop` / `_emit_while_loop`: cast the accumulator back to `src.dtype` inside the loop body when the operation promotes the type.
   - `_emit_if_else` / `_emit_while_in_if` / `_emit_nested_if_in_if`: unconditional `.to()` casts at the end of every branch ensure the SSA phi-node type is consistent, even when Triton's type inference differs from our model.
   - `_emit_loop_with_branch`: both inner branches cast back to `src.dtype`.

Made changes.