### PR TITLE
feat: add scatter (indirect store) operations to fuzzer

### DIFF
--- a/src/tritonfuzz/driver.py
+++ b/src/tritonfuzz/driver.py
@@ -188,7 +188,10 @@ class CompilerDriver:
         num_inputs = kernel.metadata.get("num_inputs", 1)
         input_dtypes = kernel.metadata.get("input_dtypes")
         output_dtype = kernel.metadata.get("output_dtype")
-        sig = self._build_signature(jit_fn, num_inputs, input_dtypes, output_dtype)
+        sig = self._build_signature(
+            jit_fn, num_inputs, input_dtypes, output_dtype,
+            metadata=kernel.metadata,
+        )
 
         # ── Step 4: build constexprs for tl.constexpr parameters ─────────
         constexprs = self._build_constexprs(kernel, jit_fn)
@@ -238,10 +241,12 @@ class CompilerDriver:
         num_inputs: int,
         input_dtypes: list[str] | None = None,
         output_dtype: str | None = None,
+        metadata: dict | None = None,
     ) -> dict[str, str]:
         """Build the positional-argument signature dict for ``triton.compile``.
 
-        Layout: ``in_ptr0, in_ptr1, …, out_ptr, n_elements`` (constexprs excluded).
+        Layout: ``in_ptr0, in_ptr1, …, [scatter_idx_ptr,] out_ptr, n_elements``
+        (constexprs excluded).
         Keys are parameter *names* (strings), matching the current Triton API.
         Parameters marked ``tl.constexpr`` are excluded from the signature.
 
@@ -257,6 +262,9 @@ class CompilerDriver:
             ``"*fp32"``.
         output_dtype:
             PyTorch dtype string for the output pointer. Defaults to ``"*fp32"``.
+        metadata:
+            Kernel metadata dict.  Used to detect scatter-only mode which
+            inserts an extra ``scatter_idx_ptr`` before ``out_ptr``.
         """
         # Collect non-constexpr parameter names from the JIT function.
         import triton.language as tl
@@ -280,6 +288,12 @@ class CompilerDriver:
             )
             name = non_constexpr_names[pos] if pos < len(non_constexpr_names) else f"arg{pos}"
             sig[name] = cls._TORCH_DTYPE_TO_SIG.get(dt_str, "*fp32")
+            pos += 1
+        # scatter_idx_ptr (scatter-only mode: extra i32 pointer before out_ptr)
+        _meta = metadata or {}
+        if _meta.get("use_scatter") and not _meta.get("use_gather"):
+            name = non_constexpr_names[pos] if pos < len(non_constexpr_names) else f"arg{pos}"
+            sig[name] = "*i32"
             pos += 1
         # out_ptr
         out_sig = cls._TORCH_DTYPE_TO_SIG.get(output_dtype or "", "*fp32")

--- a/src/tritonfuzz/generator/builder.py
+++ b/src/tritonfuzz/generator/builder.py
@@ -213,6 +213,10 @@ class KernelBuilder:
         self.use_gather: bool = False
         self.gather_data_inputs: int = 0  # how many data inputs use gather
 
+        # ── Scatter mode (indirect stores via tl.store(ptr + idx)) ───
+        self.use_scatter: bool = False
+        self.scatter_unique_indices: bool = True  # True = permutation (deterministic)
+
         # ── Register-pressure stress mode ────────────────────────────────
         self.use_reg_pressure: bool = False
         self.reg_pressure_num_warps: int = 4
@@ -351,6 +355,24 @@ class KernelBuilder:
                     self.input_dtypes.append(pick_input_dtype(rng))
                 # Disable block_ptr if gather is on — they are different
                 # pointer strategies on the load side
+                self.use_block_ptr = False
+
+        # Scatter mode (12 % of NON-dot, NON-block_ptr kernels)
+        # Uses tl.store(out_ptr + idx, value) instead of contiguous
+        # tl.store(out_ptr + offsets, value), exercising unstructured
+        # scatter instruction generation.  Can coexist with gather
+        # (shared index tensor) or be standalone.
+        if not self.use_dot and not self.use_block_ptr:
+            self.use_scatter = rng.random() > 0.88
+            if self.use_scatter:
+                # Decide index uniqueness: unique (permutation) is
+                # deterministic; non-unique may have write races.
+                self.scatter_unique_indices = rng.random() > 0.40  # 60 % unique
+                if not self.use_gather:
+                    # Scatter-only: keep n_elements reasonable
+                    self.n_elements = rng.choice(_GATHER_N_ELEMENTS_CHOICES)
+                # Disable block_ptr — scattered stores are incompatible
+                # with structured block-pointer stores
                 self.use_block_ptr = False
 
         # ── Register-pressure stress (15 % of NON-dot kernels) ──────
@@ -535,6 +557,9 @@ class KernelBuilder:
         if self.use_gather:
             self._emit_gather_loads()
             return
+        if self.use_scatter and not self.use_gather:
+            self._emit_scatter_only_loads()
+            return
         if self.use_block_ptr:
             self._emit_block_ptr_loads()
             return
@@ -634,6 +659,53 @@ class KernelBuilder:
             self.symtab.add(TensorVar(var_name, dt, is_block=True))
 
         self._ops_used.append("gather_load")
+        if self.use_scatter:
+            self._ops_used.append("scatter_store")
+
+    def _emit_scatter_only_loads(self) -> None:
+        """Emit standard contiguous loads plus a scatter index load.
+
+        When scatter is active WITHOUT gather, data inputs are loaded
+        contiguously (standard path) and a separate scatter index
+        tensor is loaded.  The index is used only in the store
+        epilogue: ``tl.store(out_ptr + scatter_idx, value)``.
+
+        Pattern::
+
+            scatter_idx = tl.load(scatter_idx_ptr + offsets, mask=mask)
+            v_0 = tl.load(in_ptr0 + offsets, mask=mask)
+            v_1 = tl.load(in_ptr1 + offsets, mask=mask)
+        """
+        mask_arg = ", mask=mask" if self.use_mask else ""
+        other_arg_int = ", other=0" if self.use_mask else ""
+
+        # Load the scatter index tensor
+        self._triton_body.append(
+            f"scatter_idx = tl.load(scatter_idx_ptr + offsets{mask_arg}{other_arg_int})"
+        )
+        self._torch_body.append(
+            "scatter_idx = x_scatter_idx"
+        )
+
+        # Load data inputs contiguously (standard path)
+        for i in range(self.num_inputs):
+            var_name = self.symtab.fresh_name("v")
+            dt = self.input_dtypes[i]
+            ptr = f"in_ptr{i}"
+
+            mask_arg_data = ", mask=mask" if self.use_mask else ""
+            other_arg_data = ""
+            if self.use_mask and self.mask_use_other:
+                other_val = "0.0" if dt.is_float else "0"
+                other_arg_data = f", other={other_val}"
+            triton_line = f"{var_name} = tl.load({ptr} + offsets{mask_arg_data}{other_arg_data})"
+            torch_line = f"{var_name} = x{i}"
+
+            self._triton_body.append(triton_line)
+            self._torch_body.append(torch_line)
+            self.symtab.add(TensorVar(var_name, dt, is_block=True))
+
+        self._ops_used.append("scatter_store")
 
     # ================================================================== #
     #  Phase 3 – Emit body ops (§4.2 Tensor Graph Synthesis)               #
@@ -2078,6 +2150,8 @@ class KernelBuilder:
             return self._assemble_block_ptr_triton_source()
         if self.use_gather:
             return self._assemble_gather_triton_source()
+        if self.use_scatter:
+            return self._assemble_scatter_triton_source()
 
         seed = self.seed
         ptr_args = ", ".join(f"in_ptr{i}" for i in range(self.num_inputs))
@@ -2264,15 +2338,63 @@ class KernelBuilder:
         for line in self._triton_body:
             lines.append(f"    {line}")
 
-        # Store epilogue
+        # Store epilogue — use scatter (indirect) indexing if enabled
+        store_offset = "idx_0" if self.use_scatter else "offsets"
         if self.use_atomic and self.atomic_op is not None:
             mask_arg = ", mask=mask" if self.use_mask else ""
             lines.append(
-                f"    {self.atomic_op.triton_fn}(out_ptr + offsets, {out_var}{mask_arg})"
+                f"    {self.atomic_op.triton_fn}(out_ptr + {store_offset}, {out_var}{mask_arg})"
             )
         else:
             mask_arg = ", mask=mask" if self.use_mask else ""
-            lines.append(f"    tl.store(out_ptr + offsets, {out_var}{mask_arg})")
+            lines.append(f"    tl.store(out_ptr + {store_offset}, {out_var}{mask_arg})")
+
+        return "\n".join(lines) + "\n"
+
+    def _assemble_scatter_triton_source(self) -> str:
+        """Assemble a kernel with indirect (scatter) stores.
+
+        Data inputs are loaded contiguously; a separate scatter index
+        tensor drives the store epilogue:
+        ``tl.store(out_ptr + scatter_idx, value)``.
+        """
+        seed = self.seed
+        out_var = self._output_var.name if self._output_var else "v_0"
+
+        ptr_args = ", ".join(f"in_ptr{i}" for i in range(self.num_inputs))
+
+        lines: list[str] = [
+            "import triton",
+            "import triton.language as tl",
+            "",
+            "",
+            "@triton.jit",
+            f"def triton_kernel_seed_{seed}(",
+            f"    {ptr_args}, scatter_idx_ptr, out_ptr,",
+            "    n_elements,",
+            "    BLOCK_SIZE: tl.constexpr,",
+            "):",
+            "    pid = tl.program_id(axis=0)",
+            "    block_start = pid * BLOCK_SIZE",
+            "    offsets = block_start + tl.arange(0, BLOCK_SIZE)",
+        ]
+
+        if self.use_mask:
+            lines.append("    mask = offsets < n_elements")
+
+        # Body (includes scatter index load + data loads + ops)
+        for line in self._triton_body:
+            lines.append(f"    {line}")
+
+        # Store epilogue — indirect via scatter_idx
+        if self.use_atomic and self.atomic_op is not None:
+            mask_arg = ", mask=mask" if self.use_mask else ""
+            lines.append(
+                f"    {self.atomic_op.triton_fn}(out_ptr + scatter_idx, {out_var}{mask_arg})"
+            )
+        else:
+            mask_arg = ", mask=mask" if self.use_mask else ""
+            lines.append(f"    tl.store(out_ptr + scatter_idx, {out_var}{mask_arg})")
 
         return "\n".join(lines) + "\n"
 
@@ -2412,6 +2534,10 @@ class KernelBuilder:
             # First arg is the index tensor, then data tensors
             args = ["x_idx"] + [f"x{i}" for i in range(1, self.num_inputs)]
             input_args = ", ".join(args)
+        elif self.use_scatter:
+            # Scatter-only: data tensors + scatter index
+            args = [f"x{i}" for i in range(self.num_inputs)] + ["x_scatter_idx"]
+            input_args = ", ".join(args)
         else:
             input_args = ", ".join(f"x{i}" for i in range(self.num_inputs))
 
@@ -2427,7 +2553,22 @@ class KernelBuilder:
         for line in self._torch_body:
             lines.append(f"    {line}")
 
-        lines.append(f"    return {out_var}")
+        # Scatter mode: write to output via indexed assignment instead
+        # of returning the computed value directly.
+        if self.use_scatter:
+            # Determine scatter index variable name
+            if self.use_gather:
+                scatter_idx_var = "x_idx"  # shared with gather
+            else:
+                scatter_idx_var = "x_scatter_idx"
+            output_dtype_str = (
+                self._output_var.dtype.torch if self._output_var else "torch.float32"
+            )
+            lines.append(f"    _out = torch.zeros({scatter_idx_var}.shape[0], dtype={output_dtype_str}, device={out_var}.device)")
+            lines.append(f"    _out[{scatter_idx_var}] = {out_var}")
+            lines.append("    return _out")
+        else:
+            lines.append(f"    return {out_var}")
 
         return "\n".join(lines) + "\n"
 
@@ -2563,6 +2704,9 @@ class KernelBuilder:
             "use_block_ptr": self.use_block_ptr,
             "use_gather": self.use_gather,
             "gather_data_inputs": self.gather_data_inputs if self.use_gather else 0,
+            # ── Scatter (indirect stores) ────────────────────────────
+            "use_scatter": self.use_scatter,
+            "scatter_unique_indices": self.scatter_unique_indices if self.use_scatter else True,
             # ── Register-pressure stress ─────────────────────────────
             "use_reg_pressure": self.use_reg_pressure,
             # ── Software-pipelining stress ────────────────────────────

--- a/src/tritonfuzz/oracle.py
+++ b/src/tritonfuzz/oracle.py
@@ -127,6 +127,8 @@ _OP_TOLERANCE_MULTIPLIERS: dict[str, float] = {
     # If/else and nested-if do not add numerical error themselves
     "if_else":         1.0,
     "nested_if_in_if": 1.0,
+    # Scatter (indirect stores) – no additional numerical error
+    "scatter_store":   1.0,
 }
 
 # Output dtype → base tolerance override.
@@ -312,7 +314,15 @@ class Oracle:
             op.startswith("atomic") for op in ops_used
         )
 
-        if has_atomics:
+        # Scatter with non-unique indices: write order is
+        # non-deterministic (like atomics), so use relaxed comparison.
+        has_scatter = "scatter_store" in ops_used
+        scatter_non_unique = (
+            has_scatter
+            and not metadata.get("scatter_unique_indices", True)
+        )
+
+        if has_atomics or scatter_non_unique:
             return self._compare_atomic(seed, golden, test, ops_used, metadata)
 
         # --- Phase 3: standard numerical comparison (§6.1–6.2) ------------

--- a/src/tritonfuzz/runtime.py
+++ b/src/tritonfuzz/runtime.py
@@ -146,6 +146,8 @@ class Runtime:
             return self._allocate_dot_inputs(kernel)
         if meta.get("use_gather"):
             return self._allocate_gather_inputs(kernel)
+        if meta.get("use_scatter"):
+            return self._allocate_scatter_inputs(kernel)
         if meta.get("use_pipeline_loop"):
             return self._allocate_pipeline_inputs(kernel)
 
@@ -190,6 +192,11 @@ class Runtime:
         Input 0 is an int32 index tensor whose values are clamped to
         ``[0, n_elements)`` so all gather accesses are in-bounds.
         Remaining inputs are data tensors of the appropriate dtypes.
+
+        When scatter is also active (gather+scatter), the index tensor
+        controls both load and store addressing.  If
+        ``scatter_unique_indices`` is True, the indices form a
+        permutation (deterministic output).
         """
         meta = kernel.metadata
         n_elements = meta.get("n_elements", 1024)
@@ -199,7 +206,13 @@ class Runtime:
         tensors: list[torch.Tensor] = []
 
         # Input 0: index tensor (int32, values in [0, n_elements))
-        idx = torch.randint(0, n_elements, (n_elements,), device=self._device, dtype=torch.int32)
+        use_scatter = meta.get("use_scatter", False)
+        scatter_unique = meta.get("scatter_unique_indices", True)
+        if use_scatter and scatter_unique:
+            # Permutation: each output position written exactly once
+            idx = torch.randperm(n_elements, device=self._device).to(torch.int32)
+        else:
+            idx = torch.randint(0, n_elements, (n_elements,), device=self._device, dtype=torch.int32)
         tensors.append(idx)
 
         # Inputs 1..N: data tensors
@@ -216,6 +229,46 @@ class Runtime:
                 t = torch.randint(low, high, (n_elements,), device=self._device, dtype=dt)
 
             tensors.append(t)
+
+        return tensors
+
+    def _allocate_scatter_inputs(self, kernel: GeneratedKernel) -> list[torch.Tensor]:
+        """Allocate data + scatter-index tensors for a scatter-only kernel.
+
+        Data inputs are standard contiguous tensors.  An additional
+        scatter index tensor (int32, values in ``[0, n_elements)``) is
+        appended at the end of the input list.  This matches the kernel
+        parameter order: ``in_ptr0, in_ptr1, …, scatter_idx_ptr, out_ptr``.
+        """
+        meta = kernel.metadata
+        n_elements = meta.get("n_elements", 1024)
+        num_inputs = meta.get("num_inputs", 1)
+        dtype_strs: list[str] = meta.get("input_dtypes", ["torch.float32"] * num_inputs)
+        scatter_unique = meta.get("scatter_unique_indices", True)
+
+        tensors: list[torch.Tensor] = []
+
+        # Data tensors (standard contiguous)
+        for i in range(num_inputs):
+            dt_str = dtype_strs[i] if i < len(dtype_strs) else "torch.float32"
+            dt = _TORCH_DTYPE_MAP.get(dt_str, torch.float32)
+
+            if dt.is_floating_point:
+                t = torch.randn(n_elements, device=self._device, dtype=dt)
+            else:
+                info = torch.iinfo(dt)
+                low = max(info.min, -127)
+                high = min(info.max, 127) + 1
+                t = torch.randint(low, high, (n_elements,), device=self._device, dtype=dt)
+
+            tensors.append(t)
+
+        # Scatter index tensor (appended after data inputs)
+        if scatter_unique:
+            scatter_idx = torch.randperm(n_elements, device=self._device).to(torch.int32)
+        else:
+            scatter_idx = torch.randint(0, n_elements, (n_elements,), device=self._device, dtype=torch.int32)
+        tensors.append(scatter_idx)
 
         return tensors
 
@@ -288,7 +341,12 @@ class Runtime:
 
         # Initialise output tensor — atomic ops require specific init values
         # so that the first write is an identity (non-overlapping pattern).
+        # Scatter mode also uses zeros so untouched positions (if any) have
+        # a known value for comparison.
+        use_scatter = meta.get("use_scatter", False)
         output_init = meta.get("output_init", "empty")
+        if use_scatter and output_init == "empty":
+            output_init = "zeros"  # scatter needs deterministic init
         if output_init == "zeros":
             out = torch.zeros(n_elements, device=self._device, dtype=output_dtype)
         elif output_init == "neg_inf":


### PR DESCRIPTION
Add support for tl.store(out_ptr + idx, value) scatter operations, exercising the Triton compiler's indirect store code-generation path.

Generator (builder.py):
- Add use_scatter / scatter_unique_indices planning (~12% of non-dot kernels)
- Add _emit_scatter_only_loads() for standalone scatter mode
- Add _assemble_scatter_triton_source() for scatter-only kernels
- Modify _assemble_gather_triton_source() to reuse gather idx for stores
- Modify _assemble_torch_ref_source() with indexed-assignment semantics
- Track 'scatter_store' in ops_used and scatter fields in metadata

Runtime (runtime.py):
- Add _allocate_scatter_inputs() with permutation (unique) or random (non-unique) indices
- Modify _allocate_gather_inputs() to respect scatter_unique_indices
- Route scatter-only mode in _allocate_inputs()
- Force zeros output init for scatter kernels

Oracle (oracle.py):
- Detect scatter_store in ops_used
- Route non-unique scatter indices to relaxed (atomic) comparison
- Add scatter_store tolerance multiplier (1.0)

Driver (driver.py):
- Fix _build_signature() to handle scatter_idx_ptr parameter in scatter-only kernels

Closes #13